### PR TITLE
docs: Add logo & split README file

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
-<div style="text-align:center">
-    <img style="width: 700px; height: auto;" src="https://i.imgur.com/X7j3aDw.png" />
-</div>
+<p align="center">
+  <img src="https://i.imgur.com/G8BUzdZ.png" />
+</p>
 
 ## Install
 - [Getting started](#getting-started)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,87 @@
+<div style="text-align:center">
+    <img style="width: 700px; height: auto;" src="https://i.imgur.com/X7j3aDw.png" />
+</div>
+
+## Install
+- [Getting started](#getting-started)
+- [Compatibility](#react-native-compatibility)
+- [Linking](#linking)
+
+### Getting started
+Install the library using either Yarn:
+
+```
+yarn add react-native-background-actions
+```
+
+or npm:
+
+```
+npm install --save react-native-background-actions
+```
+
+### React Native Compatibility
+To use this library you need to ensure you are using the correct version of React Native. If you are using a version of React Native that is lower than `0.47` you will need to upgrade before attempting to use this library latest version.
+
+### Linking
+
+#### Using React Native >= 0.60
+Linking the package manually is not required anymore with [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
+
+- **iOS Platform:**
+
+  `$ cd ios && pod install && cd ..` # CocoaPods on iOS needs this extra step
+  
+  The background support requires you to activate the background capability in Xcode.
+  <img width="688" alt="screenBack" src="https://user-images.githubusercontent.com/44206249/72381524-d2490e00-3717-11ea-959c-f95d94e6ae26.png">
+
+- **Android Platform:**
+
+  Modify your **`android/app/src/main/AndroidManifest.xml`** and add the following:
+  ```xml
+    <manifest ... >
+        ...
+        <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+        <uses-permission android:name="android.permission.WAKE_LOCK" />
+        ...
+        <application ... >
+            ...
+            <service android:name="com.asterinet.react.bgactions.RNBackgroundActionsTask" />
+        </application>
+      </manifest>
+  ```
+  
+  
+#### Using React Native < 0.60
+
+You then need to link the native parts of the library for the platforms you are using. The easiest way to link the library is using the CLI tool by running this command from the root of your project:
+
+`$ react-native link react-native-background-actions`
+
+If you can't or don't want to use the CLI tool, you can also manually link the library using the instructions below (click on the arrow to show them):
+
+<details>
+<summary>Manually link the library on iOS</summary>
+
+1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
+2. Go to `node_modules` ➜ `react-native-background-actions` and add `RNBackgroundActions.xcodeproj`
+3. In XCode, in the project navigator, select your project. Add `libRNBackgroundActions.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
+4. Run your project (`Cmd+R`)<
+</details>
+
+<details>
+<summary>Manually link the library on Android</summary>
+
+1. Open up `android/app/src/main/java/[...]/MainApplication.java`
+  - Add `import com.asterinet.react.bgactions.BackgroundActionsPackage;` to the imports at the top of the file
+  - Add `new BackgroundActionsPackage()` to the list returned by the `getPackages()` method
+2. Append the following lines to `android/settings.gradle`:
+  	```
+  	include ':react-native-background-actions'
+  	project(':react-native-background-actions').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-background-actions/android')
+  	```
+3. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
+  	```
+      compile project(':react-native-background-actions')
+  	```
+</details>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div style="text-align:center">
-    <img style="width: 450px; height: auto;" src="https://i.imgur.com/X7j3aDw.png" />
+    <img src="https://i.imgur.com/G8BUzdZ.png" />
     <br />
     <img src="https://github.com/Rapsssito/react-native-background-actions/workflows/Release/badge.svg" />
     <img src="https://img.shields.io/npm/dw/react-native-background-actions" />

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-<div style="text-align:center">
+<p align="center">
     <img src="https://i.imgur.com/G8BUzdZ.png" />
     <br />
     <img src="https://github.com/Rapsssito/react-native-background-actions/workflows/Release/badge.svg" />
     <img src="https://img.shields.io/npm/dw/react-native-background-actions" />
     <img src="https://img.shields.io/npm/v/react-native-background-actions?color=gr&label=npm%20version" />
-</div>
+</p>
 <br />
 
 React Native background service library for running **background tasks forever in Android & iOS**. Schedule a background job that will run your JavaScript when your app is in the background or foreground.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
-# `react-native-background-actions`
-![](https://github.com/Rapsssito/react-native-background-actions/workflows/Release/badge.svg)
-
+<div style="text-align:center">
+    <img style="width: 700px; height: auto;" src="https://i.imgur.com/X7j3aDw.png" />
+    <br />
+    <div style="display:flex; flex-direction: row; justify-content: center;">
+        <div style="margin: 0px 10px" >
+            <img src="https://github.com/Rapsssito/react-native-background-actions/workflows/Release/badge.svg" />
+        </div>
+        <div style="margin: 0px 10px">
+            <img src="https://img.shields.io/npm/dw/react-native-background-actions" />
+        </div>
+        <div style="margin: 0px 10px">
+            <img src="https://img.shields.io/npm/v/react-native-background-actions?color=gr&label=npm%20version" />
+        </div>
+    </div>
+</div>
+<br />
 
 React Native background service library for running **background tasks forever in Android & iOS**. Schedule a background job that will run your JavaScript when your app is in the background or foreground.
 
-### WARNING
+### <span style="color:Red">WARNING</span>
 - **Android**: This library relies on React Native's [`HeadlessJS`](https://facebook.github.io/react-native/docs/headless-js-android.html) for Android. Before building your JS task, make sure to read all the [documentation](https://facebook.github.io/react-native/docs/headless-js-android.html). The jobs will run even if the app has been closed.
 
 - **iOS**: This library relies on iOS's [`UIApplication beginBackgroundTaskWithName` method](https://developer.apple.com/documentation/uikit/uiapplication/1623051-beginbackgroundtaskwithname?language=objc), which **won't keep your app in the background forever** by itself. However, you can rely on other libraries like [`react-native-track-player`](https://github.com/react-native-kit/react-native-track-player) that use audio, geolocalization, etc. to keep your app alive in the background while you excute the JS from this library.
@@ -12,227 +25,19 @@ React Native background service library for running **background tasks forever i
 
 ## Table of Contents
 
-- [Getting started](#getting-started)
-- [Compatibility](#react-native-compatibility)
+- [Install](#install)
 - [Usage](#usage)
-    - [Options](#options)
-    - [Deep Linking](#deep-linking)
 - [Maintainers](#maintainers)
 - [Acknowledgments](#acknowledgments)
 - [License](#license)
 
-## Getting started
-Install the library using either Yarn:
+## Install
 
-```
-yarn add react-native-background-actions
-```
-
-or npm:
-
-```
-npm install --save react-native-background-actions
-```
-
-#### Using React Native >= 0.60
-Linking the package manually is not required anymore with [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
-
-- **iOS Platform:**
-
-  `$ cd ios && pod install && cd ..` # CocoaPods on iOS needs this extra step
-  
-  The background support requires you to activate the background capability in Xcode.
-  <img width="688" alt="screenBack" src="https://user-images.githubusercontent.com/44206249/72381524-d2490e00-3717-11ea-959c-f95d94e6ae26.png">
-
-- **Android Platform:**
-
-  Modify your **`android/app/src/main/AndroidManifest.xml`** and add the following:
-  ```xml
-    <manifest ... >
-        ...
-        <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-        <uses-permission android:name="android.permission.WAKE_LOCK" />
-        ...
-        <application ... >
-            ...
-            <service android:name="com.asterinet.react.bgactions.RNBackgroundActionsTask" />
-        </application>
-      </manifest>
-  ```
-  
-  
-#### Using React Native < 0.60
-
-You then need to link the native parts of the library for the platforms you are using. The easiest way to link the library is using the CLI tool by running this command from the root of your project:
-
-`$ react-native link react-native-background-actions`
-
-If you can't or don't want to use the CLI tool, you can also manually link the library using the instructions below (click on the arrow to show them):
-
-<details>
-<summary>Manually link the library on iOS</summary>
-
-1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
-2. Go to `node_modules` ➜ `react-native-background-actions` and add `RNBackgroundActions.xcodeproj`
-3. In XCode, in the project navigator, select your project. Add `libRNBackgroundActions.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
-4. Run your project (`Cmd+R`)<
-</details>
-
-<details>
-<summary>Manually link the library on Android</summary>
-
-1. Open up `android/app/src/main/java/[...]/MainApplication.java`
-  - Add `import com.asterinet.react.bgactions.BackgroundActionsPackage;` to the imports at the top of the file
-  - Add `new BackgroundActionsPackage()` to the list returned by the `getPackages()` method
-2. Append the following lines to `android/settings.gradle`:
-  	```
-  	include ':react-native-background-actions'
-  	project(':react-native-background-actions').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-background-actions/android')
-  	```
-3. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
-  	```
-      compile project(':react-native-background-actions')
-  	```
-</details>
-
-## React Native Compatibility
-To use this library you need to ensure you are using the correct version of React Native. If you are using a version of React Native that is lower than `0.47` you will need to upgrade before attempting to use this library latest version.
+Go to [INSTALL.md](./INSTALL.md) to see the how to install, compatibility with RN and Linking process.
 
 ## Usage
-```js
-import BackgroundService from 'react-native-background-actions';
 
-// You can do anything in your task such as network requests, timers and so on,
-// as long as it doesn't touch UI. Once your task completes (i.e. the promise is resolved),
-// React Native will go into "paused" mode (unless there are other tasks running,
-// or there is a foreground app).
-const veryIntensiveTask = async (taskDataArguments) => {
-    // Example of an infinite loop task
-    const { delay } = taskDataArguments;
-    await new Promise( async (resolve) => {
-        for (let i = 0; BackgroundService.isRunning(); i++) {
-            console.log(i);
-            await sleep(delay);
-        }
-    });
-};
-
-const options = {
-    taskName: 'Example',
-    taskTitle: 'ExampleTask title',
-    taskDesc: 'ExampleTask description',
-    taskIcon: {
-        name: 'ic_launcher',
-        type: 'mipmap',
-    },
-    color: '#ff00ff',
-    linkingURI: 'yourSchemeHere://chat/jane', // See Deep Linking for more info
-    parameters: {
-        delay: 1000,
-    },
-};
-
-
-await BackgroundService.start(veryIntensiveTask, options);
-await BackgroundService.updateNotification({taskDesc: 'New ExampleTask description'}); // Only Android, iOS will ignore this call
-// iOS will also run everything here in the background until .stop() is called
-await BackgroundService.stop();
-```
-> If you call stop() on background no new tasks will be able to be started!
-> Don't call .start() twice, as it will stop performing previous background tasks and start a new one. 
-> If .start() is called on the backgound, it will not have any effect.
-
-### Options
-| Property    | Type       | Description                                    |
-| ----------- | ---------- | ------------------------------------------------ |
-| `taskName`  | `<string>` | Task name for identification.                     |
-| `taskTitle` | `<string>` |  **Android Required**. Notification title.       |
-| `taskDesc`  | `<string>` | **Android Required**. Notification description. |
-| `taskIcon`  | [`<taskIconOptions>`](#taskIconOptions) | **Android Required**. Notification icon. |
-| `color`  | `<string>` | Notification color. **Default**: `"#ffffff"`. |
-| `linkingURI`  | `<string>` | Link that will be called when the notification is clicked. Example: `"yourSchemeHere://chat/jane"`. See [Deep Linking](#deep-linking) for more info. **Default**: `undefined`. |
-| `progressBar`  | [`<taskProgressBarOptions>`](#taskProgressBarOptions) | Notification progress bar. |
-| `parameters` | `<any>` | Parameters to pass to the task. |
-
-#### taskIconOptions
-**Android only**
-| Property    | Type       | Description                                                    |
-| ----------- | ---------- | -------------------------------------------------------------- |
-| `name`  | `<string>` | **Required**. Icon name in res/ folder. Ex: `ic_launcher`.         |
-| `type` | `<string>` |  **Required**. Icon type in res/ folder. Ex: `mipmap`.              |
-| `package`  | `<string>` | Icon package where to search the icon. Ex: `com.example.package`. **It defaults to the app's package. It is higly recommended to leave like that.** |
-
-Example:
-
-![photo5837026843969041365](https://user-images.githubusercontent.com/44206249/72532521-de49e280-3873-11ea-8bf6-00618bcb82ab.jpg)
-
-#### taskProgressBarOptions
-**Android only**
-| Property    | Type       | Description                                                    |
-| ----------- | ---------- | -------------------------------------------------------------- |
-| `max`       | `<number>` | **Required**. Maximum value.     |
-| `value`     | `<number>` |  **Required**. Current value.         |
-| `indeterminate`     | `<boolean>` |  Display the progress status as indeterminate.         |
-
-Example:
-
-![ProgressBar](https://developer.android.com/images/ui/notifications/notification-progressbar_2x.png)
-
-### Deep Linking
-**Android only**
-
-To handle incoming links when the notification is clicked by the user, first you need to modify your **`android/app/src/main/AndroidManifest.xml`** and add an `<intent-filter>` (fill `yourSchemeHere` with the name you prefer):
-```xml
-  <manifest ... >
-      ...
-      <application ... >
-          <activity
-              ...
-              android:launchMode="singleTask"> // Add this if not present
-                  ...
-                  <intent-filter android:label="filter_react_native">
-                      <action android:name="android.intent.action.VIEW" />
-                      <category android:name="android.intent.category.DEFAULT" />
-                      <category android:name="android.intent.category.BROWSABLE" />
-                      <data android:scheme="yourSchemeHere" />
-                  </intent-filter>
-      </application>
-    </manifest>
-```
-
-You must provide a `linkingURI` in the BackgroundService's [options](#options) that matches the scheme you just added to **`android/app/src/main/AndroidManifest.xml`**:
-```js
-const options = {
-    taskName: 'Example',
-    taskTitle: 'ExampleTask title',
-    taskDesc: 'ExampleTask description',
-    taskIcon: {
-        name: 'ic_launcher',
-        type: 'mipmap',
-    },
-    color: '#ff00ff',
-    linkingURI: 'yourSchemeHere://chat/jane', // Add this
-    parameters: {
-        delay: 1000,
-    },
-};
-
-
-await BackgroundService.start(veryIntensiveTask, options);
-```
-
-React Native provides a `Linking` class to get notified of incoming links. Your JavaScript code must then listen to the url using React Native `Linking` class:
-```js
-import { Linking } from 'react-native';
-
-Linking.addEventListener('url', handleOpenURL);
-
-function handleOpenURL(evt) {
-    // Will be called when the notification is pressed
-    console.log(evt.url);
-    // do something
-}
-```
+Go to [USAGE.md](./USAGE.md) to see the example code and options.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 React Native background service library for running **background tasks forever in Android & iOS**. Schedule a background job that will run your JavaScript when your app is in the background or foreground.
 
-### <span style="color:Red">WARNING</span>
+### WARNING
 - **Android**: This library relies on React Native's [`HeadlessJS`](https://facebook.github.io/react-native/docs/headless-js-android.html) for Android. Before building your JS task, make sure to read all the [documentation](https://facebook.github.io/react-native/docs/headless-js-android.html). The jobs will run even if the app has been closed.
 
 - **iOS**: This library relies on iOS's [`UIApplication beginBackgroundTaskWithName` method](https://developer.apple.com/documentation/uikit/uiapplication/1623051-beginbackgroundtaskwithname?language=objc), which **won't keep your app in the background forever** by itself. However, you can rely on other libraries like [`react-native-track-player`](https://github.com/react-native-kit/react-native-track-player) that use audio, geolocalization, etc. to keep your app alive in the background while you excute the JS from this library.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,9 @@
 <div style="text-align:center">
-    <img style="width: 700px; height: auto;" src="https://i.imgur.com/X7j3aDw.png" />
+    <img style="width: 450px; height: auto;" src="https://i.imgur.com/X7j3aDw.png" />
     <br />
-    <div style="display:flex; flex-direction: row; justify-content: center;">
-        <div style="margin: 0px 10px" >
-            <img src="https://github.com/Rapsssito/react-native-background-actions/workflows/Release/badge.svg" />
-        </div>
-        <div style="margin: 0px 10px">
-            <img src="https://img.shields.io/npm/dw/react-native-background-actions" />
-        </div>
-        <div style="margin: 0px 10px">
-            <img src="https://img.shields.io/npm/v/react-native-background-actions?color=gr&label=npm%20version" />
-        </div>
-    </div>
+    <img src="https://github.com/Rapsssito/react-native-background-actions/workflows/Release/badge.svg" />
+    <img src="https://img.shields.io/npm/dw/react-native-background-actions" />
+    <img src="https://img.shields.io/npm/v/react-native-background-actions?color=gr&label=npm%20version" />
 </div>
 <br />
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 <p align="center">
     <img src="https://i.imgur.com/G8BUzdZ.png" />
-    <br />
+    <br></br>
     <img src="https://github.com/Rapsssito/react-native-background-actions/workflows/Release/badge.svg" />
     <img src="https://img.shields.io/npm/dw/react-native-background-actions" />
     <img src="https://img.shields.io/npm/v/react-native-background-actions?color=gr&label=npm%20version" />
 </p>
-<br />
 
 React Native background service library for running **background tasks forever in Android & iOS**. Schedule a background job that will run your JavaScript when your app is in the background or foreground.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,6 +1,6 @@
-<div style="text-align:center">
-    <img style="width: 700px; height: auto;" src="https://i.imgur.com/X7j3aDw.png" />
-</div>
+<p align="center">
+  <img src="https://i.imgur.com/G8BUzdZ.png" />
+</p>
 
 ## Usage
 - [Example Code](#Example-Code)

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,145 @@
+<div style="text-align:center">
+    <img style="width: 700px; height: auto;" src="https://i.imgur.com/X7j3aDw.png" />
+</div>
+
+## Usage
+- [Example Code](#Example-Code)
+- [Options](#options)
+- [Deep Linking](#deep-linking)
+
+### Example Code
+
+```js
+import BackgroundService from 'react-native-background-actions';
+
+// You can do anything in your task such as network requests, timers and so on,
+// as long as it doesn't touch UI. Once your task completes (i.e. the promise is resolved),
+// React Native will go into "paused" mode (unless there are other tasks running,
+// or there is a foreground app).
+const veryIntensiveTask = async (taskDataArguments) => {
+    // Example of an infinite loop task
+    const { delay } = taskDataArguments;
+    await new Promise( async (resolve) => {
+        for (let i = 0; BackgroundService.isRunning(); i++) {
+            console.log(i);
+            await sleep(delay);
+        }
+    });
+};
+
+const options = {
+    taskName: 'Example',
+    taskTitle: 'ExampleTask title',
+    taskDesc: 'ExampleTask description',
+    taskIcon: {
+        name: 'ic_launcher',
+        type: 'mipmap',
+    },
+    color: '#ff00ff',
+    linkingURI: 'yourSchemeHere://chat/jane', // See Deep Linking for more info
+    parameters: {
+        delay: 1000,
+    },
+};
+
+
+await BackgroundService.start(veryIntensiveTask, options);
+await BackgroundService.updateNotification({taskDesc: 'New ExampleTask description'}); // Only Android, iOS will ignore this call
+// iOS will also run everything here in the background until .stop() is called
+await BackgroundService.stop();
+```
+> If you call stop() on background no new tasks will be able to be started!
+> Don't call .start() twice, as it will stop performing previous background tasks and start a new one. 
+> If .start() is called on the backgound, it will not have any effect.
+
+### Options
+| Property    | Type       | Description                                    |
+| ----------- | ---------- | ------------------------------------------------ |
+| `taskName`  | `<string>` | Task name for identification.                     |
+| `taskTitle` | `<string>` |  **Android Required**. Notification title.       |
+| `taskDesc`  | `<string>` | **Android Required**. Notification description. |
+| `taskIcon`  | [`<taskIconOptions>`](#taskIconOptions) | **Android Required**. Notification icon. |
+| `color`  | `<string>` | Notification color. **Default**: `"#ffffff"`. |
+| `linkingURI`  | `<string>` | Link that will be called when the notification is clicked. Example: `"yourSchemeHere://chat/jane"`. See [Deep Linking](#deep-linking) for more info. **Default**: `undefined`. |
+| `progressBar`  | [`<taskProgressBarOptions>`](#taskProgressBarOptions) | Notification progress bar. |
+| `parameters` | `<any>` | Parameters to pass to the task. |
+
+#### taskIconOptions
+**Android only**
+| Property    | Type       | Description                                                    |
+| ----------- | ---------- | -------------------------------------------------------------- |
+| `name`  | `<string>` | **Required**. Icon name in res/ folder. Ex: `ic_launcher`.         |
+| `type` | `<string>` |  **Required**. Icon type in res/ folder. Ex: `mipmap`.              |
+| `package`  | `<string>` | Icon package where to search the icon. Ex: `com.example.package`. **It defaults to the app's package. It is higly recommended to leave like that.** |
+
+Example:
+
+![photo5837026843969041365](https://user-images.githubusercontent.com/44206249/72532521-de49e280-3873-11ea-8bf6-00618bcb82ab.jpg)
+
+#### taskProgressBarOptions
+**Android only**
+| Property    | Type       | Description                                                    |
+| ----------- | ---------- | -------------------------------------------------------------- |
+| `max`       | `<number>` | **Required**. Maximum value.     |
+| `value`     | `<number>` |  **Required**. Current value.         |
+| `indeterminate`     | `<boolean>` |  Display the progress status as indeterminate.         |
+
+Example:
+
+![ProgressBar](https://developer.android.com/images/ui/notifications/notification-progressbar_2x.png)
+
+### Deep Linking
+**Android only**
+
+To handle incoming links when the notification is clicked by the user, first you need to modify your **`android/app/src/main/AndroidManifest.xml`** and add an `<intent-filter>` (fill `yourSchemeHere` with the name you prefer):
+```xml
+  <manifest ... >
+      ...
+      <application ... >
+          <activity
+              ...
+              android:launchMode="singleTask"> // Add this if not present
+                  ...
+                  <intent-filter android:label="filter_react_native">
+                      <action android:name="android.intent.action.VIEW" />
+                      <category android:name="android.intent.category.DEFAULT" />
+                      <category android:name="android.intent.category.BROWSABLE" />
+                      <data android:scheme="yourSchemeHere" />
+                  </intent-filter>
+      </application>
+    </manifest>
+```
+
+You must provide a `linkingURI` in the BackgroundService's [options](#options) that matches the scheme you just added to **`android/app/src/main/AndroidManifest.xml`**:
+```js
+const options = {
+    taskName: 'Example',
+    taskTitle: 'ExampleTask title',
+    taskDesc: 'ExampleTask description',
+    taskIcon: {
+        name: 'ic_launcher',
+        type: 'mipmap',
+    },
+    color: '#ff00ff',
+    linkingURI: 'yourSchemeHere://chat/jane', // Add this
+    parameters: {
+        delay: 1000,
+    },
+};
+
+
+await BackgroundService.start(veryIntensiveTask, options);
+```
+
+React Native provides a `Linking` class to get notified of incoming links. Your JavaScript code must then listen to the url using React Native `Linking` class:
+```js
+import { Linking } from 'react-native';
+
+Linking.addEventListener('url', handleOpenURL);
+
+function handleOpenURL(evt) {
+    // Will be called when the notification is pressed
+    console.log(evt.url);
+    // do something
+}
+```


### PR DESCRIPTION
Hi,
It's October and Hacktoberfest just started and I thought this year I'll go throw the repositories that I used during this year in my projects and see if there is any help I can offer. react-native-background-actions helped me in two projects this year as I found it a pretty good solution for running background tasks in RN after a long-term searching for a way to implement such a feature.

This pull request contains two additions to the documentations:
1- a simple logo for the repository as logos gives a high quality impression.
2- splitting the README file to multiple files with links to each file to help keeping things organize. too many information and code snippets in one long file causes the reader to lost track of what he should do to start using the package. splitting the README file to INSTALL and USAGE files will help solving this problem.

thanks for this package and hope you'll find this PR useful. 😀