### PR TITLE
Regenerate index.d.ts

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -6,7 +6,7 @@ export type BackgroundTaskOptions = {
     taskIcon: {
         name: string;
         type: string;
-        package?: string | undefined;
+        package?: string;
     };
     color?: string | undefined;
     linkingURI?: string | undefined;
@@ -51,20 +51,20 @@ declare class BackgroundServer {
      *          progressBar?: {max: number, value: number, indeterminate?: boolean}}} taskData
      */
     updateNotification(taskData: {
-        taskTitle?: string | undefined;
-        taskDesc?: string | undefined;
+        taskTitle?: string;
+        taskDesc?: string;
         taskIcon?: {
             name: string;
             type: string;
-            package?: string | undefined;
-        } | undefined;
-        color?: string | undefined;
-        linkingURI?: string | undefined;
+            package?: string;
+        };
+        color?: string;
+        linkingURI?: string;
         progressBar?: {
             max: number;
             value: number;
-            indeterminate?: boolean | undefined;
-        } | undefined;
+            indeterminate?: boolean;
+        };
     }): Promise<void>;
     /**
      * Returns if the current background task is running.
@@ -79,23 +79,7 @@ declare class BackgroundServer {
      * @param {BackgroundTaskOptions & {parameters?: any}} options
      * @returns {Promise<void>}
      */
-    start(task: (taskData: any) => Promise<void>, options: {
-        taskName: string;
-        taskTitle: string;
-        taskDesc: string;
-        taskIcon: {
-            name: string;
-            type: string;
-            package?: string | undefined;
-        };
-        color?: string | undefined;
-        linkingURI?: string | undefined;
-        progressBar?: {
-            max: number;
-            value: number;
-            indeterminate?: boolean | undefined;
-        } | undefined;
-    } & {
+    start(task: (taskData: any) => Promise<void>, options: BackgroundTaskOptions & {
         parameters?: any;
     }): Promise<void>;
     /**

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -50,7 +50,7 @@ declare class BackgroundServer {
      *          linkingURI?: string,
      *          progressBar?: {max: number, value: number, indeterminate?: boolean}}} taskData
      */
-    async updateNotification(taskData: {
+    updateNotification(taskData: {
         taskTitle?: string | undefined;
         taskDesc?: string | undefined;
         taskIcon?: {
@@ -79,7 +79,7 @@ declare class BackgroundServer {
      * @param {BackgroundTaskOptions & {parameters?: any}} options
      * @returns {Promise<void>}
      */
-    async start(task: (taskData: any) => Promise<void>, options: {
+    start(task: (taskData: any) => Promise<void>, options: {
         taskName: string;
         taskTitle: string;
         taskDesc: string;
@@ -114,5 +114,5 @@ declare class BackgroundServer {
      *
      * @returns {Promise<void>}
      */
-    async stop(): Promise<void>;
+    stop(): Promise<void>;
 }


### PR DESCRIPTION
`async`s in class declarations produce following errors:

```
node_modules/react-native-background-actions/lib/types/index.d.ts:53:5 - error TS1040: 'async' modifier cannot be used in an ambient context.

53     async updateNotification(taskData: {
       ~~~~~

node_modules/react-native-background-actions/lib/types/index.d.ts:82:5 - error TS1040: 'async' modifier cannot be used in an ambient context.

82     async start(task: (taskData: any) => Promise<void>, options: {
       ~~~~~

node_modules/react-native-background-actions/lib/types/index.d.ts:117:5 - error TS1040: 'async' modifier cannot be used in an ambient context.
117     async stop(): Promise<void>;
        ~~~~~

Found 3 errors.
```

This compilation error is totally valid, as `async` modifier is needed for function implementation only. For function declarations it is enough to mark it as returning `Promise`.