### PR TITLE
feat(iOS): Add 'expiration' event

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -6,6 +6,7 @@
 - [Example Code](#Example-Code)
 - [Options](#options)
 - [Deep Linking](#deep-linking)
+- [Events](#events)
 
 ### Example Code
 
@@ -142,4 +143,18 @@ function handleOpenURL(evt) {
     console.log(evt.url);
     // do something
 }
+```
+
+### Events
+#### 'expiration'
+**iOS only**
+Listen for the iOS-only expiration handler that allows you to 'clean up' shortly before the app’s remaining background time reaches 0. Check the iOS [documentation](https://developer.apple.com/documentation/uikit/uiapplication/1623031-beginbackgroundtask) for more info.
+
+```js
+BackgroundService.on('expiration', () => {
+    console.log('I am being closed :(');
+});
+
+await BackgroundService.start(veryIntensiveTask, options);
+
 ```

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,6 +1,6 @@
 import { Platform, AppRegistry } from 'react-native';
 import BackgroundActions from '../src/index';
-import RNBackgroundActionsModule from '../src/RNBackgroundActionsModule';
+import { RNBackgroundActions as RNBackgroundActionsModule } from '../src/RNBackgroundActionsModule';
 
 // Flush promises
 const flushPromises = () => new Promise(setImmediate);

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,6 +1,12 @@
 import { Platform, AppRegistry } from 'react-native';
 import BackgroundActions from '../src/index';
-import { RNBackgroundActions as RNBackgroundActionsModule } from '../src/RNBackgroundActionsModule';
+import {
+    RNBackgroundActions as RNBackgroundActionsModule,
+    nativeEventEmitter,
+} from '../src/RNBackgroundActionsModule';
+
+// @ts-ignore
+const mockedEventEmitter = /** @type {{ addListener: jest.Mock<any, any> }} */ (nativeEventEmitter);
 
 // Flush promises
 const flushPromises = () => new Promise(setImmediate);
@@ -122,4 +128,12 @@ test('updateNotification-android-notRunning', async () => {
     Platform.OS = 'android';
     const updatedOptions = { taskDesc: 'New Desc' };
     await expect(BackgroundActions.updateNotification(updatedOptions)).rejects.toBeDefined();
+});
+
+test('expiration-event', () => {
+    Platform.OS = 'ios';
+    return new Promise((done) => {
+        BackgroundActions.on('expiration', done);
+        mockedEventEmitter.addListener.mock.calls[0][1]();
+    });
 });

--- a/examples/backgroundExample/.prettierrc
+++ b/examples/backgroundExample/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "tabWidth": 4,
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "bracketSpacing": true,
+  "printWidth": 100,
+  "jsxBracketSameLine": true,
+  "arrowParens": "always"
+}

--- a/examples/backgroundExample/App.js
+++ b/examples/backgroundExample/App.js
@@ -8,129 +8,129 @@
 
 import React from 'react';
 import {
-  SafeAreaView,
-  StyleSheet,
-  ScrollView,
-  View,
-  Text,
-  StatusBar,
-  TouchableOpacity,
-  Platform,
-  Linking,
+    SafeAreaView,
+    StyleSheet,
+    ScrollView,
+    View,
+    Text,
+    StatusBar,
+    TouchableOpacity,
+    Platform,
+    Linking,
 } from 'react-native';
-import {Header, Colors} from 'react-native/Libraries/NewAppScreen';
+import { Header, Colors } from 'react-native/Libraries/NewAppScreen';
 
 import BackgroundJob from 'react-native-background-actions';
 
-const sleep = time => new Promise(resolve => setTimeout(() => resolve(), time));
+const sleep = (time) => new Promise((resolve) => setTimeout(() => resolve(), time));
 
-const taskRandom = async taskData => {
-  if (Platform.OS === 'ios') {
-    console.warn(
-      'This task will not keep your app alive in the background by itself, use other library like react-native-track-player that use audio,',
-      'geolocalization, etc. to keep your app alive in the background while you excute the JS from this library.',
-    );
-  }
-  await new Promise(async resolve => {
-    // For loop with a delay
-    const {delay} = taskData;
-    for (let i = 0; BackgroundJob.isRunning(); i++) {
-      console.log('Runned -> ', i);
-      await BackgroundJob.updateNotification({taskDesc: 'Runned -> ' + i});
-      await sleep(delay);
+const taskRandom = async (taskData) => {
+    if (Platform.OS === 'ios') {
+        console.warn(
+            'This task will not keep your app alive in the background by itself, use other library like react-native-track-player that use audio,',
+            'geolocalization, etc. to keep your app alive in the background while you excute the JS from this library.'
+        );
     }
-  });
+    await new Promise(async (resolve) => {
+        // For loop with a delay
+        const { delay } = taskData;
+        console.log(BackgroundJob.isRunning(), delay)
+        for (let i = 0; BackgroundJob.isRunning(); i++) {
+            console.log('Runned -> ', i);
+            await BackgroundJob.updateNotification({ taskDesc: 'Runned -> ' + i });
+            await sleep(delay);
+        }
+    });
 };
 
 const options = {
-  taskName: 'Example',
-  taskTitle: 'ExampleTask title',
-  taskDesc: 'ExampleTask desc',
-  taskIcon: {
-    name: 'ic_launcher',
-    type: 'mipmap',
-  },
-  color: '#ff00ff',
-  linkingURI: 'exampleScheme://chat/jane',
-  parameters: {
-    delay: 1000,
-  },
+    taskName: 'Example',
+    taskTitle: 'ExampleTask title',
+    taskDesc: 'ExampleTask desc',
+    taskIcon: {
+        name: 'ic_launcher',
+        type: 'mipmap',
+    },
+    color: '#ff00ff',
+    linkingURI: 'exampleScheme://chat/jane',
+    parameters: {
+        delay: 1000,
+    },
 };
 
-
 function handleOpenURL(evt) {
-  console.log(evt.url);
-  // do something with the url
+    console.log(evt.url);
+    // do something with the url
 }
 
 Linking.addEventListener('url', handleOpenURL);
 
 class App extends React.Component {
-  playing = BackgroundJob.isRunning();
+    playing = BackgroundJob.isRunning();
 
-  /**
-   * Toggles the background task
-   */
-  toggleBackground = async () => {
-    this.playing = !this.playing;
-    if (this.playing) {
-      try {
-        console.log('Trying to start background service');
-        await BackgroundJob.start(taskRandom, options);
-        console.log('Successful start!');
-      } catch (e) {
-        console.log('Error', e);
-      }
-    } else {
-      console.log('Stop background service');
-      await BackgroundJob.stop();
+    /**
+     * Toggles the background task
+     */
+    toggleBackground = async () => {
+        this.playing = !this.playing;
+        if (this.playing) {
+            try {
+                console.log('Trying to start background service');
+                await BackgroundJob.start(taskRandom, options);
+                console.log('Successful start!');
+            } catch (e) {
+                console.log('Error', e);
+            }
+        } else {
+            console.log('Stop background service');
+            await BackgroundJob.stop();
+        }
+    };
+    render() {
+        return (
+            <>
+                <StatusBar barStyle="dark-content" />
+                <SafeAreaView>
+                    <ScrollView
+                        contentInsetAdjustmentBehavior="automatic"
+                        style={styles.scrollView}>
+                        <Header />
+                        {global.HermesInternal == null ? null : (
+                            <View style={styles.engine}>
+                                <Text style={styles.footer}>Engine: Hermes</Text>
+                            </View>
+                        )}
+                        <View style={styles.body}>
+                            <TouchableOpacity
+                                style={{ height: 100, width: 100, backgroundColor: 'red' }}
+                                onPress={this.toggleBackground}></TouchableOpacity>
+                        </View>
+                    </ScrollView>
+                </SafeAreaView>
+            </>
+        );
     }
-  };
-  render() {
-    return (
-      <>
-        <StatusBar barStyle="dark-content" />
-        <SafeAreaView>
-          <ScrollView
-            contentInsetAdjustmentBehavior="automatic"
-            style={styles.scrollView}>
-            <Header />
-            {global.HermesInternal == null ? null : (
-              <View style={styles.engine}>
-                <Text style={styles.footer}>Engine: Hermes</Text>
-              </View>
-            )}
-            <View style={styles.body}>
-              <TouchableOpacity
-                style={{height: 100, width: 100, backgroundColor: 'red'}}
-                onPress={this.toggleBackground}></TouchableOpacity>
-            </View>
-          </ScrollView>
-        </SafeAreaView>
-      </>
-    );
-  }
 }
 
 const styles = StyleSheet.create({
-  scrollView: {
-    backgroundColor: Colors.lighter,
-  },
-  engine: {
-    position: 'absolute',
-    right: 0,
-  },
-  body: {
-    backgroundColor: Colors.white,
-  },
-  footer: {
-    color: Colors.dark,
-    fontSize: 12,
-    fontWeight: '600',
-    padding: 4,
-    paddingRight: 12,
-    textAlign: 'right',
-  },
+    scrollView: {
+        backgroundColor: Colors.lighter,
+    },
+    engine: {
+        position: 'absolute',
+        right: 0,
+    },
+    body: {
+        backgroundColor: Colors.white,
+    },
+    footer: {
+        color: Colors.dark,
+        fontSize: 12,
+        fontWeight: '600',
+        padding: 4,
+        paddingRight: 12,
+        textAlign: 'right',
+    },
 });
 
 export default App;

--- a/examples/backgroundExample/App.js
+++ b/examples/backgroundExample/App.js
@@ -24,6 +24,10 @@ import BackgroundJob from 'react-native-background-actions';
 
 const sleep = (time) => new Promise((resolve) => setTimeout(() => resolve(), time));
 
+BackgroundJob.on('expiration', () => {
+    console.log('iOS: I am being closed!');
+});
+
 const taskRandom = async (taskData) => {
     if (Platform.OS === 'ios') {
         console.warn(

--- a/examples/backgroundExample/ios/Podfile.lock
+++ b/examples/backgroundExample/ios/Podfile.lock
@@ -182,8 +182,8 @@ PODS:
     - React-cxxreact (= 0.61.5)
     - React-jsi (= 0.61.5)
   - React-jsinspector (0.61.5)
-  - react-native-background-actions (1.0.2):
-    - React
+  - react-native-background-actions (2.5.3):
+    - React-Core
   - React-RCTActionSheet (0.61.5):
     - React-Core/RCTActionSheetHeaders (= 0.61.5)
   - React-RCTAnimation (0.61.5):
@@ -238,7 +238,7 @@ DEPENDENCIES:
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
-  - react-native-background-actions (from `../node_modules/react-native-background-actions`)
+  - react-native-background-actions (from `../../..`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
   - React-RCTBlob (from `../node_modules/react-native/Libraries/Blob`)
@@ -286,7 +286,7 @@ EXTERNAL SOURCES:
   React-jsinspector:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   react-native-background-actions:
-    :path: "../node_modules/react-native-background-actions"
+    :path: "../../.."
   React-RCTActionSheet:
     :path: "../node_modules/react-native/Libraries/ActionSheetIOS"
   React-RCTAnimation:
@@ -326,7 +326,7 @@ SPEC CHECKSUMS:
   React-jsi: cb2cd74d7ccf4cffb071a46833613edc79cdf8f7
   React-jsiexecutor: d5525f9ed5f782fdbacb64b9b01a43a9323d2386
   React-jsinspector: fa0ecc501688c3c4c34f28834a76302233e29dc0
-  react-native-background-actions: 32e0074e222bc4adaa811fd52df820853280296b
+  react-native-background-actions: 6acd6f3b369ab93e80e47018c61e7d60586c2d8d
   React-RCTActionSheet: 600b4d10e3aea0913b5a92256d2719c0cdd26d76
   React-RCTAnimation: 791a87558389c80908ed06cc5dfc5e7920dfa360
   React-RCTBlob: d89293cc0236d9cb0933d85e430b0bbe81ad1d72
@@ -341,4 +341,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 6d56a26ae5d1018372dcc850090bad58f9b1c9d0
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.10.1

--- a/examples/backgroundExample/metro.config.js
+++ b/examples/backgroundExample/metro.config.js
@@ -1,17 +1,35 @@
-/**
- * Metro configuration for React Native
- * https://github.com/facebook/react-native
- *
- * @format
- */
+const fs = require('fs');
+const path = require('path');
+const blacklist = require('metro-config/src/defaults/blacklist');
+const escape = require('escape-string-regexp');
+
+const root = path.resolve(__dirname, '../..');
+const pak = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+
+const modules = [
+    '@babel/runtime',
+    ...Object.keys({
+        ...pak.dependencies,
+        ...pak.peerDependencies,
+    }),
+];
 
 module.exports = {
-  transformer: {
-    getTransformOptions: async () => ({
-      transform: {
-        experimentalImportSupport: false,
-        inlineRequires: false,
-      },
-    }),
-  },
+    projectRoot: __dirname,
+    watchFolders: [root],
+    resolver: {
+        blacklistRE: blacklist([new RegExp(`^${escape(path.join(root, 'node_modules'))}\\/.*$`)]),
+        extraNodeModules: modules.reduce((acc, name) => {
+            acc[name] = path.join(__dirname, 'node_modules', name);
+            return acc;
+        }, {}),
+    },
+    transformer: {
+        getTransformOptions: async () => ({
+            transform: {
+                experimentalImportSupport: false,
+                inlineRequires: false,
+            },
+        }),
+    },
 };

--- a/examples/backgroundExample/package.json
+++ b/examples/backgroundExample/package.json
@@ -13,17 +13,19 @@
   "dependencies": {
     "react": "16.9.0",
     "react-native": "0.61.5",
-    "react-native-background-actions": "^2.4.0"
+    "react-native-background-actions": "link:../../"
   },
   "devDependencies": {
     "@babel/core": "^7.8.3",
     "@babel/runtime": "^7.8.3",
     "@react-native-community/eslint-config": "^0.0.6",
     "babel-jest": "^24.9.0",
+    "escape-string-regexp": "^4.0.0",
     "eslint": "^6.8.0",
     "jest": "^24.9.0",
     "metro-react-native-babel-preset": "^0.56.4",
-    "react-test-renderer": "16.9.0"
+    "react-test-renderer": "16.9.0",
+    "typescript": "^4.2.3"
   },
   "jest": {
     "preset": "react-native"

--- a/examples/backgroundExample/yarn.lock
+++ b/examples/backgroundExample/yarn.lock
@@ -2165,6 +2165,11 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
 escodegen@^1.9.1:
   version "1.12.1"
   resolved "https://registry.npmjs.org/escodegen/-/escodegen-1.12.1.tgz#08770602a74ac34c7a90ca9229e7d51e379abc76"
@@ -5032,10 +5037,9 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
-react-native-background-actions@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/react-native-background-actions/-/react-native-background-actions-2.4.0.tgz#04efba08ff2598a5ee70a1bdafd6f666db36620f"
-  integrity sha512-wc/zrAeg+AdPhN0mNmVBHZl0z0jnY34tO+BpLktqPyrrO7olAXE/EruVuOHEnaGCUWgRNNlk2lqq4WLa/RVSRw==
+"react-native-background-actions@link:../..":
+  version "0.0.0"
+  uid ""
 
 react-native@0.61.5:
   version "0.61.5"
@@ -6055,6 +6059,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 ua-parser-js@^0.7.18:
   version "0.7.21"

--- a/ios/RNBackgroundActions.h
+++ b/ios/RNBackgroundActions.h
@@ -1,5 +1,6 @@
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface RNBackgroundActions : NSObject <RCTBridgeModule>
+@interface RNBackgroundActions : RCTEventEmitter<RCTBridgeModule>
 
 @end

--- a/ios/RNBackgroundActions.m
+++ b/ios/RNBackgroundActions.m
@@ -6,13 +6,16 @@
 }
 
 RCT_EXPORT_MODULE()
+- (NSArray<NSString *> *)supportedEvents
+{
+    return @[@"expiration"];
+}
 
 - (void) _start
 {
     [self _stop];
     bgTask = [[UIApplication sharedApplication] beginBackgroundTaskWithName:@"RNBackgroundActions" expirationHandler:^{
-        // Clean up any unfinished task business by marking where you
-        // stopped or ending the task outright.
+        [self onExpiration];
         [[UIApplication sharedApplication] endBackgroundTask: self->bgTask];
         self->bgTask = UIBackgroundTaskInvalid;
     }];
@@ -24,6 +27,12 @@ RCT_EXPORT_MODULE()
         [[UIApplication sharedApplication] endBackgroundTask:bgTask];
         bgTask = UIBackgroundTaskInvalid;
     }
+}
+
+- (void)onExpiration
+{
+    [self sendEventWithName:@"expiration"
+                       body:@{}];
 }
 
 RCT_EXPORT_METHOD(start:(NSDictionary *)options

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,4 @@
 jest.mock('./src/RNBackgroundActionsModule.js', () => ({
     RNBackgroundActions: { start: jest.fn(), stop: jest.fn(), updateNotification: jest.fn() },
-    nativeEventEmitter: { addListener: jest.fn() }
+    nativeEventEmitter: { addListener: jest.fn() },
 }));

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,4 @@
 jest.mock('./src/RNBackgroundActionsModule.js', () => ({
-    start: jest.fn(),
-    stop: jest.fn(),
-    updateNotification: jest.fn(),
+    RNBackgroundActions: { start: jest.fn(), stop: jest.fn(), updateNotification: jest.fn() },
+    nativeEventEmitter: { addListener: jest.fn() }
 }));

--- a/package.json
+++ b/package.json
@@ -71,5 +71,7 @@
     "semantic-release": "^17.0.1",
     "typescript": "4.0.3"
   },
-  "dependencies": {}
+  "dependencies": {
+    "eventemitter3": "^4.0.7"
+  }
 }

--- a/react-native-background-actions.podspec
+++ b/react-native-background-actions.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => "9.0", :tvos => "10.0" }
   s.source       = { :git => s.homepage, :tag => "#v{s.version}" }
 
-  s.source_files = "ios/**/*.{h,m,swift}"
+  s.source_files = "ios/*.{h,m,swift}"
   s.requires_arc = true
 
   s.dependency "React-Core"

--- a/src/RNBackgroundActionsModule.js
+++ b/src/RNBackgroundActionsModule.js
@@ -1,5 +1,7 @@
-import { NativeModules } from 'react-native';
+import { NativeEventEmitter, NativeModules } from 'react-native';
 
 const { RNBackgroundActions } = NativeModules;
 
-export default RNBackgroundActions;
+const nativeEventEmitter = new NativeEventEmitter(RNBackgroundActions);
+
+export { RNBackgroundActions, nativeEventEmitter };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "noEmit": true,
         "strict": true,
         "skipLibCheck": true,
+        "esModuleInterop": true
     },
     "include": ["src/index.js", "__tests__/", "__mocks__/"],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3240,6 +3240,11 @@ eventemitter3@^3.0.0:
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
+eventemitter3@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 exec-sh@^0.3.2:
   version "0.3.4"
   resolved "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"


### PR DESCRIPTION
Listen for the iOS-only expiration handler that allows you to 'clean up' shortly before the app’s remaining background time reaches 0.

Fixes #72 