### PR TITLE
fix: Fix creation of multiple tasks

### DIFF
--- a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
+++ b/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
@@ -79,12 +79,21 @@ final public class RNBackgroundActionsTask extends HeadlessJsTaskService {
         if (extras == null) {
             throw new IllegalArgumentException("Extras cannot be null");
         }
-        final BackgroundTaskOptions bgOptions = new BackgroundTaskOptions(extras);
+        final Options bgOptions = new Options(extras);
         createNotificationChannel(bgOptions.getTaskTitle(), bgOptions.getTaskDesc()); // Necessary creating channel for API 26+
         // Create the notification
         final Notification notification = buildNotification(this, bgOptions);
+
         startForeground(SERVICE_NOTIFICATION_ID, notification);
-        return super.onStartCommand(intent, flags, startId);
+
+        HeadlessJsTaskConfig taskConfig = this.getTaskConfig(intent);
+
+        if (taskConfig != null) {
+            this.stopForeground(false);
+            this.startTask(taskConfig);
+        }
+
+        return START_NOT_STICKY;
     }
 
     private void createNotificationChannel(@NonNull final String taskTitle, @NonNull final String taskDesc) {

--- a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
+++ b/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
@@ -79,7 +79,7 @@ final public class RNBackgroundActionsTask extends HeadlessJsTaskService {
         if (extras == null) {
             throw new IllegalArgumentException("Extras cannot be null");
         }
-        final Options bgOptions = new Options(extras);
+        final BackgroundTaskOptions bgOptions = new BackgroundTaskOptions(extras);
         createNotificationChannel(bgOptions.getTaskTitle(), bgOptions.getTaskDesc()); // Necessary creating channel for API 26+
         // Create the notification
         final Notification notification = buildNotification(this, bgOptions);


### PR DESCRIPTION
Fixes issue #121 

When Task is running and the app is killed multiple times the task shouldn't always be created new but instead restart like desired