### PR TITLE
fix(Android) solving the problem with starting the service on Android OS version 12+ (#181)

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.asterinet.react.bgactions">
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <application>
+        <service android:name=".RNBackgroundActionsTask"/>
+    </application>
 </manifest>


### PR DESCRIPTION
Register background service in package AndroidManifest.xml
https://reactnative.dev/docs/headless-js-android?android-language=kotlin

Related [issue](https://github.com/Rapsssito/react-native-background-actions/issues/181)