### PR TITLE
Fix Android RN 0.73 namespace requirement

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,6 +11,11 @@ android {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', 34)
     }
+
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace = "com.asterinet.react.bgactions"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
follow https://stackoverflow.com/questions/76108428/how-do-i-fix-namespace-not-specified-error-in-android-studio

and https://github.com/getsentry/sentry-react-native/blob/main/android/build.gradle#L17C5-L20C6

which fixed Android Gradle Plugin error >= 8.x.x