### PR TITLE
fix(Android): remove invalid onTimeout(int, int) override incompatible with compileSdk 34

### DIFF
--- a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
+++ b/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
@@ -122,12 +122,6 @@ final public class RNBackgroundActionsTask extends HeadlessJsTaskService {
         stopSelf(startId);
     }
 
-    @Override
-    public void onTimeout(int startId, int fgsType) {
-        super.onTimeout(startId, fgsType);
-        stopSelf(startId);
-    }
-
     private void createNotificationChannel(@NonNull final String taskTitle, @NonNull final String taskDesc) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             final int importance = NotificationManager.IMPORTANCE_LOW;


### PR DESCRIPTION
## Problem

The two-argument `onTimeout(int startId, int fgsType)` overload was introduced
in Android API 35 (VANILLA_ICE_CREAM). Using `@Override` against the default
`compileSdkVersion 34` causes a compile error — the method does not exist in
the base `android.app.Service` class at that API level.

## Fix

Remove the API-35-only overload. The existing `onTimeout(int startId)` already
calls `stopSelf(startId)`, which is sufficient to stop the service on all
supported API levels.